### PR TITLE
Add Dockerfile and Compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM rust:1.64 AS buildbase
+WORKDIR /src
+RUN <<EOT bash
+    set -ex
+    apt-get update
+    apt-get install -y \
+        git \
+        clang
+    rustup target add wasm32-wasi
+EOT
+# This line installs WasmEdge including the AOT compiler
+RUN curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
+
+FROM buildbase AS build
+COPY . .
+# Build the Wasm binary
+RUN --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/cache \
+    --mount=type=cache,target=/usr/local/cargo/registry/index \
+    cargo build --target wasm32-wasi --release
+# This line builds the AOT Wasm binary
+RUN /root/.wasmedge/bin/wasmedgec target/wasm32-wasi/release/order_demo_service.wasm order_demo_service.wasm
+
+FROM scratch
+ENTRYPOINT [ "order_demo_service.wasm" ]
+COPY --link --from=build /src/order_demo_service.wasm /order_demo_service.wasm

--- a/README.md
+++ b/README.md
@@ -75,3 +75,28 @@ curl http://localhost:8080/delete_order?id=2
 
 That's it. Feel free to fork this project and use it as a template for your own lightweight microservices!
 
+## Test with Docker
+
+Using a version of Docker with Wasm WASI support, start the example stack using `docker compose`:
+
+```bash
+docker compose up
+```
+
+Initialize the database using the `/init` endpoint:
+
+```bash
+docker run --rm --network host curlimages/curl curl http://localhost:8080/init
+```
+
+List the current orders using the `/orders` endpoint:
+
+```bash
+docker run --rm --network host curlimages/curl curl http://localhost:8080/orders
+```
+
+Add the example orders:
+
+```bash
+cat orders.json | docker run --rm --network host -i curlimages/curl curl http://localhost:8080/create_orders -X POST -d @-
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  server:
+    image: server
+    build:
+      context: .
+      platforms:
+        - wasi/wasm32
+    ports:
+      - 8080:8080
+    network_mode: host
+    environment:
+      DATABASE_URL: mysql://root:whalehello@localhost:3306/mysql
+      RUST_BACKTRACE: full
+    restart: unless-stopped
+    runtime: io.containerd.wasmedge.v1
+  db:
+    image: mariadb:10.9
+    environment:
+      MYSQL_ROOT_PASSWORD: whalehello
+    network_mode: host


### PR DESCRIPTION
This requires a version of Docker with Wasm WASI support to work.

Steps to test:
1. Run `docker compose up`
2. Run `docker run --rm --network host curlimages/curl curl http://0.0.0.0:8080/init` to initialize
