### PR TITLE
Remove host networking requirement for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,5 @@ Using a version of Docker with Wasm WASI support, start the example stack using 
 docker compose up
 ```
 
-Initialize the database using the `/init` endpoint:
-
-```bash
-docker run --rm --network host curlimages/curl curl http://localhost:8080/init
-```
-
-List the current orders using the `/orders` endpoint:
-
-```bash
-docker run --rm --network host curlimages/curl curl http://localhost:8080/orders
-```
-
-Add the example orders:
-
-```bash
-cat orders.json | docker run --rm --network host -i curlimages/curl curl http://localhost:8080/create_orders -X POST -d @-
-```
+This will build and run the Rust Wasm server and startup a MySQL backing database.
+You can then follow the steps above to interact with the Web server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
         - wasi/wasm32
     ports:
       - 8080:8080
-    network_mode: host
     environment:
-      DATABASE_URL: mysql://root:whalehello@localhost:3306/mysql
+      DATABASE_URL: mysql://root:whalehello@db:3306/mysql
       RUST_BACKTRACE: full
     restart: unless-stopped
     runtime: io.containerd.wasmedge.v1
@@ -17,4 +16,3 @@ services:
     image: mariadb:10.9
     environment:
       MYSQL_ROOT_PASSWORD: whalehello
-    network_mode: host


### PR DESCRIPTION
Now that Wasm modules don't require host networking with Desktop, update the Compose file and README.