### PR TITLE
compose: Fix platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./client:/usr/share/nginx/html
   server:
     image: demo-microservice
-    platform: wasi/wasm32
+    platform: wasi/wasm
     build:
       context: .
     ports:


### PR DESCRIPTION
The OCI has decided that we should use wasi/wasm instead of wasi/wasm32

See: https://github.com/opencontainers/image-spec/pull/964