### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM rust:1.64 AS buildbase
+FROM --platform=$BUILDPLATFORM rust:1.69 AS buildbase
 WORKDIR /src
 RUN <<EOT bash
     set -ex


### PR DESCRIPTION
Suggested fix for following error, new to docker but my impression is that this should work
#0 2.063 error: package `time-core v0.1.1` cannot be built because it requires rustc 1.65.0 or newer, while the currently active rustc version is 1.64.0

Taken from their official image page on docker hub, 
https://hub.docker.com/_/rust
https://github.com/rust-lang/docker-rust/tree/35579d26bda862c00d127d63cee4ab9cd5d114c2/1.69.0
