### PR TITLE
Fix DNS error on WASM adding static IPs to every container on a new network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       - 8090:80
     volumes:
       - ./client:/usr/share/nginx/html
+    networks:
+      fixed:
+        ipv4_address: 172.20.0.3
   server:
     image: demo-microservice
     platform: wasi/wasm
@@ -13,12 +16,25 @@ services:
     ports:
       - 8080:8080
     environment:
-      DATABASE_URL: mysql://root:whalehello@db:3306/mysql
+      DATABASE_URL: mysql://root:whalehello@172.20.0.5:3306/mysql
       RUST_BACKTRACE: full
       DNS_SERVER: 127.0.0.11:53
     restart: unless-stopped
     runtime: io.containerd.wasmedge.v1
+    networks:
+      fixed:
+        ipv4_address: 172.20.0.4
   db:
     image: mariadb:10.9
     environment:
       MYSQL_ROOT_PASSWORD: whalehello
+    networks:
+      fixed:
+        ipv4_address: 172.20.0.5
+networks:
+  fixed:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.0.0/16


### PR DESCRIPTION
This change solves an error with Docker's DNS. With this, instead of relying on the DNS, we assign static IPs to every container on a new network called "Fixed" and we specify the exact DB direction on the DATABASE_URL env variable.